### PR TITLE
Fix load autocomplete crash when quicksaves dir doesn't exist

### DIFF
--- a/Features/Quicksave.cs
+++ b/Features/Quicksave.cs
@@ -151,6 +151,9 @@ namespace FEZUG.Features
 
                 var quicksaveDir = Path.Combine(Util.LocalConfigFolder, SaveDirectory);
 
+                if (!Directory.Exists(quicksaveDir))
+                    return null;
+
                 return Directory.GetFiles(quicksaveDir).Select(path => Path.GetFileName(path))
                     .Where(name => name.StartsWith(args[0])).ToList();
             }


### PR DESCRIPTION
Reported by Wilko in the speedrun discord server.