### PR TITLE
Show all quicksaves when entering load with no arguments

### DIFF
--- a/Features/Quicksave.cs
+++ b/Features/Quicksave.cs
@@ -113,6 +113,21 @@ namespace FEZUG.Features
 
             public bool Execute(string[] args)
             {
+                if (args.Length == 0)
+                {
+                    List<string> paths = Autocomplete([""]);
+                    if (paths == null || paths.Count == 0)
+                    {
+                        FezugConsole.Print("No available quicksaves");
+                    }
+                    else
+                    {
+                        FezugConsole.Print("List of available quicksaves:");
+                        FezugConsole.Print(string.Join(" ", paths));
+                    }
+                    return true;
+                }
+
                 if (GameState.ActiveSaveDevice == null)
                 {
                     FezugConsole.Print($"Can't load while the game is loading.", FezugConsole.OutputType.Error);


### PR DESCRIPTION
Entering `load` with no arguments will print the list of available quicksaves, similar to `warp`.

Closes #8 