### PR TITLE
Cleanup code

### DIFF
--- a/FEZUG.cs
+++ b/FEZUG.cs
@@ -1,19 +1,9 @@
-﻿using Common;
-using FezEngine.Components;
-using FezEngine.Tools;
+﻿using FezEngine.Tools;
 using FezGame;
-using FezGame.Components;
-using FezGame.Services;
 using FEZUG.Features;
-using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG
 {
@@ -41,7 +31,7 @@ namespace FEZUG
 
             DrawingTools.Init();
 
-            Features = new List<IFezugFeature>();
+            Features = [];
             foreach (Type type in Assembly.GetExecutingAssembly().GetTypes()
             .Where(t => t.IsClass && typeof(IFezugFeature).IsAssignableFrom(t)))
             {

--- a/Features/Allow3DRotation.cs
+++ b/Features/Allow3DRotation.cs
@@ -1,11 +1,6 @@
 ﻿using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {

--- a/Features/AnnoyanceRemoval.cs
+++ b/Features/AnnoyanceRemoval.cs
@@ -7,12 +7,7 @@ using FezGame.Structure;
 using FEZUG.Features.Console;
 using Microsoft.Xna.Framework;
 using MonoMod.RuntimeDetour;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -39,7 +34,7 @@ namespace FEZUG.Features
             // removing dot loading screens
             LevelManagerChangeLevelDetour = new Hook(
                 typeof(GameLevelManager).GetMethod("ChangeLevel"),
-                (Action<Action<GameLevelManager, string>, GameLevelManager, string>)ChangeLevelHooked);
+                ChangeLevelHooked);
             var DotLoadLevelsField = typeof(GameLevelManager).GetField("DotLoadLevels", BindingFlags.NonPublic | BindingFlags.Instance);
             DotLoadLevelsReference = (List<string>)DotLoadLevelsField.GetValue(LevelManager);
             OriginalDotLoadLevels = new List<string>(DotLoadLevelsReference);
@@ -103,7 +98,7 @@ namespace FEZUG.Features
                     SinceStartedField.SetValue(IntroPanDown, Distance);
                 }
             }
-            
+
         }
 
         public void DrawHUD(GameTime gameTime)

--- a/Features/ArtObjectInfo.cs
+++ b/Features/ArtObjectInfo.cs
@@ -1,8 +1,4 @@
-﻿using Common;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using FezGame.Services;
 using FezEngine.Tools;
 using FEZUG.Features.Console;
@@ -25,7 +21,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-		public List<string> Autocomplete(string[] _args) { return new List<string> { }; }
+		public List<string> Autocomplete(string[] _args) { return []; }
 
 		public bool Execute(string[] args)
 		{
@@ -89,11 +85,11 @@ namespace FEZUG.Features
                             }
                             if(actorSettings.VibrationPattern != null && actorSettings.VibrationPattern.Length > 0)
                             {
-                                FezugConsole.Print($"VibrationPattern: {String.Join(", ", actorSettings.VibrationPattern)}");
+                                FezugConsole.Print($"VibrationPattern: {string.Join(", ", actorSettings.VibrationPattern)}");
                             }
                             if(actorSettings.CodePattern != null && actorSettings.CodePattern.Length > 0)
                             {
-                                FezugConsole.Print($"CodePattern: {String.Join(", ", actorSettings.CodePattern)}");
+                                FezugConsole.Print($"CodePattern: {string.Join(", ", actorSettings.CodePattern)}");
                             }
                             //if (actorSettings.Segment != null)
                             //{
@@ -117,7 +113,7 @@ namespace FEZUG.Features
                             }
                             if (actorSettings.InvisibleSides != null && actorSettings.InvisibleSides.Count > 0)
                             {
-                                FezugConsole.Print($"InvisibleSides: {String.Join(", ", actorSettings.InvisibleSides)}");
+                                FezugConsole.Print($"InvisibleSides: {string.Join(", ", actorSettings.InvisibleSides)}");
                             }
                             //if (actorSettings.NextNodeAo != null)
                             //{
@@ -142,7 +138,7 @@ namespace FEZUG.Features
                 FezugConsole.Print($"Unknown art object ID: {args[0]}");
                 return false;
             }
-            result += String.Join(", ", LevelManager.ArtObjects.Keys);
+            result += string.Join(", ", LevelManager.ArtObjects.Keys);
 			FezugConsole.Print(result);
 			return true;
 		}
@@ -167,7 +163,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-        public List<string> Autocomplete(string[] _args) { return new List<string> { }; }
+        public List<string> Autocomplete(string[] _args) { return []; }
 
         public bool Execute(string[] args)
         {
@@ -181,7 +177,7 @@ namespace FEZUG.Features
             {
                 PlayerManager.IgnoreFreefall = true;
                 PlayerManager.Position = artObjectInstance.Bounds.GetCenter();
-                return true; 
+                return true;
             }
             FezugConsole.Print("Art Object ID given does not exist in the current level.");
             return false;

--- a/Features/ArtifactItemSet.cs
+++ b/Features/ArtifactItemSet.cs
@@ -2,11 +2,6 @@
 using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -19,28 +14,25 @@ namespace FEZUG.Features
         [ServiceDependency]
         public IGameStateManager GameState { private get; set; }
 
-        public readonly ActorType[] AllowedActorTypes = new ActorType[]
-        {
+        public readonly ActorType[] AllowedActorTypes =
+        [
             ActorType.Tome,
             ActorType.TriSkull,
             ActorType.LetterCube,
             ActorType.NumberCube
-        };
+        ];
 
         public List<string> Autocomplete(string[] args)
         {
             if (args.Length == 1)
             {
-                return new string[] { "give", "remove", "list" }
-                .Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))
-                .ToList();
+                return [.. new string[] { "give", "remove", "list" }.Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))];
             }
             if (args.Length == 2)
             {
-                return AllowedActorTypes
+                return [.. AllowedActorTypes
                     .Select(s => s.ToString().ToLower())
-                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase))];
             }
             return null;
         }
@@ -60,12 +52,12 @@ namespace FEZUG.Features
                 if (args.Length >= 1 && (args[0] == "remove" || args[0] == "list"))
                 {
                     FezugConsole.Print($"List of artifacts in your inventory:");
-                    FezugConsole.Print($"{String.Join(", ", GameState.SaveData.Artifacts.Select(s => s.ToString().ToLower()))}");
+                    FezugConsole.Print($"{string.Join(", ", GameState.SaveData.Artifacts.Select(s => s.ToString().ToLower()))}");
                 }
                 else
                 {
                     FezugConsole.Print($"List of available artifacts:");
-                    FezugConsole.Print($"{String.Join(", ", artifactList.Select(s => s.ToLower()))}");
+                    FezugConsole.Print($"{string.Join(", ", artifactList.Select(s => s.ToLower()))}");
                 }
                 return true;
             }

--- a/Features/BindingSystem.cs
+++ b/Features/BindingSystem.cs
@@ -5,12 +5,6 @@ using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -30,7 +24,7 @@ namespace FEZUG.Features
         public BindingSystem()
         {
             Instance = this;
-            Binds = new BindList();
+            Binds = [];
         }
 
         public void Initialize() {
@@ -84,12 +78,10 @@ namespace FEZUG.Features
 
         private static void SaveBinds()
         {
-            using (StreamWriter bindFile = new StreamWriter(GetBindsFilePath()))
+            using StreamWriter bindFile = new(GetBindsFilePath());
+            foreach (var bind in Instance.Binds)
             {
-                foreach(var bind in Instance.Binds)
-                {
-                    bindFile.WriteLine($"{bind.Key} {bind.Value}");
-                }
+                bindFile.WriteLine($"{bind.Key} {bind.Value}");
             }
         }
 
@@ -100,7 +92,7 @@ namespace FEZUG.Features
             var bindFileLines = File.ReadAllLines(bindFilePath);
             foreach(var line in bindFileLines)
             {
-                string[] tokens = line.Split(new char[] { ' ' }, 2);
+                string[] tokens = line.Split([' '], 2);
                 if (tokens.Length < 2) continue;
 
                 if(Enum.TryParse(tokens[0], out Keys key))
@@ -119,13 +111,13 @@ namespace FEZUG.Features
             {
                 if (args.Length == 1)
                 {
-                    return Enum.GetNames(typeof(Keys)).Select(s=>s.ToLower()).Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase)).ToList();
+                    return [.. Enum.GetNames(typeof(Keys)).Select(s=>s.ToLower()).Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))];
                 }
 
                 if (args.Length == 2 && Enum.TryParse<Keys>(args[0], true, out var key)
                 && HasBind(key) && GetBind(key).StartsWith(args[1], StringComparison.OrdinalIgnoreCase))
                 {
-                    return new List<string> { GetBind(key) };
+                    return [GetBind(key)];
                 }
                 return null;
             }
@@ -178,7 +170,7 @@ namespace FEZUG.Features
             {
                 if (args.Length == 1)
                 {
-                    return Enum.GetNames(typeof(Keys)).Select(s => s.ToLower()).Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase)).ToList();
+                    return [.. Enum.GetNames(typeof(Keys)).Select(s => s.ToLower()).Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))];
                 }
 
                 return null;

--- a/Features/BlackHoleManip.cs
+++ b/Features/BlackHoleManip.cs
@@ -1,19 +1,10 @@
-﻿using Common;
-using FezEngine.Services;
-using FezEngine.Structure;
+﻿using FezEngine.Structure;
 using FezEngine.Tools;
-using FezGame;
 using FezGame.Components;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using Microsoft.Xna.Framework;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -42,7 +33,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-            return new string[] { "on", "off", "lock", "unlock" }.Where(s => s.StartsWith(args[0])).ToList();
+            return [.. new string[] { "on", "off", "lock", "unlock" }.Where(s => s.StartsWith(args[0]))];
         }
 
         public bool Execute(string[] args)

--- a/Features/Console/CommandHelp.cs
+++ b/Features/Console/CommandHelp.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace FEZUG.Features.Console
+﻿namespace FEZUG.Features.Console
 {
     internal class CommandHelp : IFezugCommand
     {
@@ -32,9 +26,9 @@ namespace FEZUG.Features.Console
                 var helpStrings = new List<string>();
                 helpStrings.AddRange(cmdList.Select(cmd => cmd.HelpText));
                 helpStrings.AddRange(varList.Select(var => $"{var.Name} - {var.HelpText}"));
-                helpStrings = helpStrings
-                    .SelectMany(str => str.Split(new[] {'\n'}))
-                    .OrderBy(str => str).ToList();
+                helpStrings = [.. helpStrings
+                    .SelectMany(str => str.Split(['\n']))
+                    .OrderBy(str => str)];
 
                 int pageCount = (int)Math.Ceiling(helpStrings.Count / (float)CommandListPageSize);
                 pageNumber = Math.Min(Math.Max(pageNumber, 1), pageCount);
@@ -50,7 +44,7 @@ namespace FEZUG.Features.Console
 
                 return true;
             }
-            else 
+            else
             {
                 var validCommands = cmdList.Where(cmd => cmd.Name.Equals(args[0], StringComparison.OrdinalIgnoreCase));
                 var validVariables = varList.Where(var => var.Name.Equals(args[0], StringComparison.OrdinalIgnoreCase));

--- a/Features/Console/ConsoleClear.cs
+++ b/Features/Console/ConsoleClear.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace FEZUG.Features.Console
+﻿namespace FEZUG.Features.Console
 {
     internal class ConsoleClear : IFezugCommand
     {

--- a/Features/Console/ConsoleToggle.cs
+++ b/Features/Console/ConsoleToggle.cs
@@ -1,10 +1,4 @@
 ﻿using FezEngine.Components;
-using FezEngine.Tools;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features.Console
 {

--- a/Features/Console/FezugVariable.cs
+++ b/Features/Console/FezugVariable.cs
@@ -1,11 +1,5 @@
 ﻿using Common;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features.Console
 {
@@ -13,7 +7,7 @@ namespace FEZUG.Features.Console
     {
         public const string VariablesFileName = "FezugVars";
 
-        public static List<FezugVariable> DefinedList { get; private set; } = new List<FezugVariable>();
+        public static List<FezugVariable> DefinedList { get; private set; } = [];
         private static Dictionary<string, string> LoadedVariables { get; set; }
 
         public readonly string Name;
@@ -26,7 +20,7 @@ namespace FEZUG.Features.Console
 
         public string ValueString
         {
-            get => _valueString; 
+            get => _valueString;
             set
             {
                 if (value.Length == 0) return;
@@ -39,8 +33,8 @@ namespace FEZUG.Features.Console
             }
         }
 
-        public float ValueFloat { 
-            get => _valueFloat; 
+        public float ValueFloat {
+            get => _valueFloat;
             set
             {
                 _valueString = value.ToString();
@@ -51,7 +45,7 @@ namespace FEZUG.Features.Console
                 VariableChanged();
             }
         }
-        public int ValueInt { 
+        public int ValueInt {
             get => _valueInt;
             set
             {
@@ -63,7 +57,7 @@ namespace FEZUG.Features.Console
                 VariableChanged();
             }
         }
-        public bool ValueBool { 
+        public bool ValueBool {
             get => _valueBool;
             set
             {
@@ -125,27 +119,25 @@ namespace FEZUG.Features.Console
 
         private static void SaveVariables()
         {
-            using (StreamWriter varsFile = new StreamWriter(GetVariablesFilePath()))
+            using StreamWriter varsFile = new(GetVariablesFilePath());
+            foreach (var command in DefinedList)
             {
-                foreach (var command in DefinedList)
-                {
-                    if (!command.SaveOnChange) continue;
-                    varsFile.WriteLine($"{command.Name} {command.ValueString}");
-                }
+                if (!command.SaveOnChange) continue;
+                varsFile.WriteLine($"{command.Name} {command.ValueString}");
             }
         }
 
         private static void LoadVariables()
         {
             if (LoadedVariables != null) return;
-            LoadedVariables = new Dictionary<string, string>();
+            LoadedVariables = [];
 
             var varsFilePath = GetVariablesFilePath();
             if (!File.Exists(varsFilePath)) return;
             var varsFileLines = File.ReadAllLines(varsFilePath);
             foreach (var line in varsFileLines)
             {
-                string[] tokens = line.Split(new char[] { ' ' }, 2);
+                string[] tokens = line.Split([' '], 2);
                 if (tokens.Length < 2) continue;
 
                 LoadedVariables[tokens[0]] = tokens[1];

--- a/Features/Console/IFezugCommand.cs
+++ b/Features/Console/IFezugCommand.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace FEZUG.Features.Console
+﻿namespace FEZUG.Features.Console
 {
     public interface IFezugCommand
     {

--- a/Features/GetTrileInfo.cs
+++ b/Features/GetTrileInfo.cs
@@ -1,14 +1,8 @@
-﻿using FezEngine.Services;
-using FezEngine.Structure;
+﻿using FezEngine.Structure;
 using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -39,7 +33,7 @@ namespace FEZUG.Features
             default: return null;
             }
 
-            return new List<string> { value.ToString("0", CultureInfo.InvariantCulture) };
+            return [value.ToString("0", CultureInfo.InvariantCulture)];
         }
 
 

--- a/Features/GomezHitboxDraw.cs
+++ b/Features/GomezHitboxDraw.cs
@@ -1,21 +1,11 @@
-﻿using FezEngine;
-using FezEngine.Components;
-using FezEngine.Effects;
-using FezEngine.Services;
+﻿using FezEngine.Effects;
 using FezEngine.Structure;
-using FezEngine.Structure.Geometry;
 using FezEngine.Tools;
-using FezGame.Components;
 using FezGame.Services;
 using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -59,7 +49,7 @@ namespace FEZUG.Features
                 Color c = trileColor;
                 TrileBoundingBox.AddWireframeBox(Vector3.One, Vector3.Zero, new Color(c.R, c.G, c.B, 32), true);
                 TrileBoundingBox.AddColoredBox(Vector3.One, Vector3.Zero, new Color(c.R, c.G, c.B, 32), true);
-                
+
             });
         }
 
@@ -95,7 +85,7 @@ namespace FEZUG.Features
 
             public List<string> Autocomplete(string[] args)
             {
-                return new string[] { "on", "off" }.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[] { "on", "off" }.Where(s => s.StartsWith(args[0]))];
             }
 
             public bool Execute(string[] args)

--- a/Features/Hud/HudPositioner.cs
+++ b/Features/Hud/HudPositioner.cs
@@ -1,9 +1,6 @@
 ﻿using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace FEZUG.Features.Hud
 {
@@ -15,24 +12,24 @@ namespace FEZUG.Features.Hud
         public HudPositioner(string name, string helpText, float defaultX, float defaultY)
         {
             XCoordVariable = new FezugVariable(
-                $"{name}_hud_position_x", 
+                $"{name}_hud_position_x",
                 $"Changes the X position of {helpText} HUD (value between 0 and 1)",
                 defaultX.ToString()
             )
             {
                 SaveOnChange = true,
-                Min = 0, 
+                Min = 0,
                 Max = 1
             };
 
             YCoordVariable = new FezugVariable(
-                $"{name}_hud_position_y", 
+                $"{name}_hud_position_y",
                 $"Changes the Y position of {helpText} HUD (value between 0 and 1)",
                 defaultY.ToString()
             )
             {
                 SaveOnChange = true,
-                Min = 0, 
+                Min = 0,
                 Max = 1
             };
         }

--- a/Features/Hud/TextHud.cs
+++ b/Features/Hud/TextHud.cs
@@ -4,18 +4,13 @@ using FezGame.Services;
 using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features.Hud
 {
     public class TextHud : IFezugFeature
     {
-        private List<(FezugVariable var, Func<string> provider)> hudVars = [];
+        private readonly List<(FezugVariable var, Func<string> provider)> hudVars = [];
 
         private FezugVariable hud_hide;
 
@@ -60,7 +55,7 @@ namespace FEZUG.Features.Hud
             CreateHudVariable("hud_velocity", "Gomez's velocity", () => $"Velocity: {FormatVector3(PlayerManager.Velocity)}");
             CreateHudVariable("hud_state", "Gomez's state", () => $"State: {PlayerManager.Action}");
             CreateHudVariable("hud_viewpoint", "camera viewpoint", () => $"Viewpoint: {CameraManager.Viewpoint}");
-            CreateHudVariable("hud_daytime", "Time of day", () => $"Time of day: {TimeManager.CurrentTime.TimeOfDay.ToString(@"hh':'mm':'ss")}");
+            CreateHudVariable("hud_daytime", "Time of day", () => $"Time of day: {TimeManager.CurrentTime.TimeOfDay:hh':'mm':'ss}");
 
             hud_hide = new FezugVariable("hud_hide", "If set, hides FEZUG HUD entirely when console is not opened.", "0")
             {
@@ -98,33 +93,11 @@ namespace FEZUG.Features.Hud
                 $"FEZUG {Fezug.Version}"
             };
 
-            foreach (var hudVar in hudVars)
+            foreach (var (var, provider) in hudVars)
             {
-                if(hudVar.var.ValueBool)
+                if(var.ValueBool)
                 {
-                    linesToDraw.Add(hudVar.provider());
-                }
-            }
-
-            {
-                string Viewpoint = "";
-                switch (CameraManager.Viewpoint)
-                {
-                    case FezEngine.Viewpoint.Back:
-                        Viewpoint = "Back";
-                        break;
-                    case FezEngine.Viewpoint.Left:
-                        Viewpoint = "Left";
-                        break;
-                    case FezEngine.Viewpoint.Right:
-                        Viewpoint = "Right";
-                        break;
-                    case FezEngine.Viewpoint.Front:
-                        Viewpoint = "Front";
-                        break;
-                    default:
-                        Viewpoint = "Other";
-                        break;
+                    linesToDraw.Add(provider());
                 }
             }
 
@@ -143,7 +116,7 @@ namespace FEZUG.Features.Hud
 
             DrawingTools.DrawRect(new Rectangle((int)(position.X + margin), (int)(position.Y + margin), (int)width, (int)height), new Color(10, 10, 10, 220));
 
-            
+
             for (int i = 0; i < linesToDraw.Count; i++)
             {
                 var line = linesToDraw[i];

--- a/Features/InvisibleTrilesDraw.cs
+++ b/Features/InvisibleTrilesDraw.cs
@@ -2,18 +2,12 @@
 using FezEngine.Effects;
 using FezEngine.Services;
 using FezEngine.Structure;
-using FezEngine.Structure.Geometry;
 using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -49,7 +43,7 @@ namespace FEZUG.Features
         {
             DrawActionScheduler.Schedule(delegate
             {
-                invisibleTriles = new Dictionary<TrileEmplacement, InvisibleType>();
+                invisibleTriles = [];
                 LevelManager.LevelChanged += RefreshTrileList;
 
                 TrileBoundingBoxes = new Mesh[3];
@@ -61,12 +55,12 @@ namespace FEZUG.Features
                     AlphaIsEmissive = true
                 };
 
-                Color[] trileColors = new Color[]
-                {
+                Color[] trileColors =
+                [
                 Color.Gray,
                 Color.White,
                 Color.Magenta
-                };
+                ];
 
                 for (var i = 0; i < 3; i++)
                 {
@@ -74,10 +68,9 @@ namespace FEZUG.Features
                     {
                         DepthWrites = false,
                         Blending = BlendingMode.Alphablending,
-                        Culling = CullMode.CullClockwiseFace
+                        Culling = CullMode.CullClockwiseFace,
+                        Effect = effect
                     };
-
-                    TrileBoundingBoxes[i].Effect = effect;
 
                     Color c = trileColors[i];
                     if (i == 0)
@@ -156,7 +149,7 @@ namespace FEZUG.Features
 
             public List<string> Autocomplete(string[] args)
             {
-                return new string[] { "on", "off" }.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[] { "on", "off" }.Where(s => s.StartsWith(args[0]))];
             }
 
             public bool Execute(string[] args)

--- a/Features/ItemCountSet.cs
+++ b/Features/ItemCountSet.cs
@@ -1,11 +1,6 @@
 ﻿using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -28,7 +23,7 @@ namespace FEZUG.Features
                 return false;
             }
 
-            Int32.TryParse(args[1], out var amount);
+            int.TryParse(args[1], out var amount);
             string itemName = "";
 
             switch (args[0])
@@ -71,7 +66,7 @@ namespace FEZUG.Features
         {
             if(args.Length == 1)
             {
-                return new string[]{ "goldens", "antis", "bits", "hearts", "keys", "owls"}.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[]{ "goldens", "antis", "bits", "hearts", "keys", "owls"}.Where(s => s.StartsWith(args[0]))];
             }
             else if(args.Length == 2 && args[1].Length == 0)
             {
@@ -91,7 +86,7 @@ namespace FEZUG.Features
                     case "owls":
                         value = GameState.SaveData.CollectedOwls; break;
                 }
-                return new List<string>() { value.ToString() };
+                return [value.ToString()];
             }
             return null;
         }

--- a/Features/Kill.cs
+++ b/Features/Kill.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FezEngine.Components;
+﻿using FezEngine.Components;
 using FezEngine.Services;
 using FezEngine.Structure;
 using FezEngine.Structure.Input;
@@ -8,8 +7,6 @@ using FezGame.Services;
 using FEZUG.Features.Console;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
-using System.Collections.Generic;
-using System.Globalization;
 
 namespace FEZUG.Features
 {

--- a/Features/LevelTimer.cs
+++ b/Features/LevelTimer.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using FezEngine.Services;
-using FezEngine.Structure;
+﻿using FezEngine.Services;
 using FezEngine.Tools;
-using FezGame.Components;
 using FezGame.Services;
 using FEZUG.Features.Console;
 using FEZUG.Helpers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.Xna.Framework;
 using FEZUG.Features.Hud;
 
@@ -18,7 +12,7 @@ namespace FEZUG.Features
     {
         public string Name => "timer";
 
-        public string HelpText => "timer <start_level> <end_level> - creates a timer between two level entrances." 
+        public string HelpText => "timer <start_level> <end_level> - creates a timer between two level entrances."
             +"\ntimer clear - clear the current timer.";
 
         private bool enabled = false;
@@ -30,15 +24,15 @@ namespace FEZUG.Features
         private string endLevel = "";
 
         private TimeSpan lastTime = TimeSpan.Zero;
-        private List<TimeSpan> timeHistory = new List<TimeSpan>();
+        private readonly List<TimeSpan> timeHistory = [];
 
 
         private string lastTimerString = "THIS IS A TEST";
 
-        private GameTime currentTime = new GameTime();
-        private GameTime startTime = new GameTime();
+        private GameTime currentTime = new();
+        private GameTime startTime = new();
 
-        private HudPositioner Positioner;
+        private readonly HudPositioner Positioner;
 
         [ServiceDependency]
         public ILevelManager LevelManager { private get; set; }

--- a/Features/MapItemSet.cs
+++ b/Features/MapItemSet.cs
@@ -1,12 +1,7 @@
 ﻿using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -21,26 +16,23 @@ namespace FEZUG.Features
 
         public List<string> GetMapList()
         {
-            return MemoryContentManager.AssetNames
+            return [.. MemoryContentManager.AssetNames
                 .Where(s => s.ToLower().StartsWith("other textures\\maps\\"))
                 .Select(s => Regex.Match(s.ToUpper(), @".*\\(.*?)(?:_\d+.*)").Groups[1].Value)
-                .Distinct().ToList();
+                .Distinct()];
         }
 
         public List<string> Autocomplete(string[] args)
         {
             if(args.Length == 1)
             {
-                return new string[] { "give", "remove", "list" }
-                .Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))
-                .ToList();
+                return [.. new string[] { "give", "remove", "list" }.Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))];
             }
             if(args.Length == 2)
             {
-                return GetMapList()
+                return [.. GetMapList()
                     .Select(s=>s.ToLower())
-                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase))];
             }
             return null;
         }
@@ -60,16 +52,16 @@ namespace FEZUG.Features
                 if(args.Length >= 1 && (args[0] == "remove" || args[0] == "list"))
                 {
                     FezugConsole.Print($"List of maps in your inventory:");
-                    FezugConsole.Print($"{String.Join(", ", GameState.SaveData.Maps.Select(s=>s.ToLower()))}");
+                    FezugConsole.Print($"{string.Join(", ", GameState.SaveData.Maps.Select(s=>s.ToLower()))}");
                 }
                 else
                 {
                     FezugConsole.Print($"List of available maps:");
-                    FezugConsole.Print($"{String.Join(", ", mapList.Select(s => s.ToLower()))}");
+                    FezugConsole.Print($"{string.Join(", ", mapList.Select(s => s.ToLower()))}");
                 }
                 return true;
             }
-            
+
             var mapName = args[1].ToUpper();
 
             if (!mapList.Contains(args[1].ToUpper()))

--- a/Features/ProgressSet.cs
+++ b/Features/ProgressSet.cs
@@ -1,10 +1,6 @@
-﻿using FezEngine.Structure;
-using FezEngine.Tools;
+﻿using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace FEZUG.Features
@@ -20,11 +16,11 @@ namespace FEZUG.Features
         [ServiceDependency]
         public IGameLevelManager LevelManager { private get; set; }
 
-        public List<string> AllowedFlagNames = new List<string>
-        {
+        public List<string> AllowedFlagNames =
+        [
             "CanNewGamePlus", "IsNewGamePlus", "Finished32", "Finished64", "HasFPView", "HasStereo3D", "HasDoneHeartReboot",
             "FezHidden", "HasHadMapHelp", "CanOpenMap", "AchievementCheatCodeDone", "MapCheatCodeDone", "AnyCodeDeciphered",
-        };
+        ];
 
         public bool Execute(string[] args)
         {
@@ -49,7 +45,7 @@ namespace FEZUG.Features
                 if (isFlag)
                 {
                     FezugConsole.Print($"List of available flags:");
-                    FezugConsole.Print(String.Join(", ", AllowedFlagNames));
+                    FezugConsole.Print(string.Join(", ", AllowedFlagNames));
                     return true;
                 }
                 else
@@ -220,25 +216,25 @@ namespace FEZUG.Features
         {
             if (args.Length == 1)
             {
-                return new string[] { "flag", "level", "all" }.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[] { "flag", "level", "all" }.Where(s => s.StartsWith(args[0]))];
             }
             else if (args.Length == 3 || args[0] == "all")
             {
-                return new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[args.Length-1])).ToList();
+                return [.. new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[args.Length-1]))];
             }
             else if (args.Length == 2)
             {
                 if (args[0] == "level")
                 {
-                    var list = WarpLevel.Instance.Autocomplete(new string[]{ args[1] });
+                    var list = WarpLevel.Instance.Autocomplete([args[1]]);
                     list.AddRange(
-                        new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[1])).ToList()
+                        [.. new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[1]))]
                     );
                     return list;
                 }
                 else if (args[0] == "flag")
                 {
-                    return AllowedFlagNames.Where(s => s.StartsWith(args[1])).ToList();
+                    return [.. AllowedFlagNames.Where(s => s.StartsWith(args[1]))];
                 }
             }
 

--- a/Features/Quicksave.cs
+++ b/Features/Quicksave.cs
@@ -1,20 +1,8 @@
-﻿using EasyStorage;
-using FezEngine.Components;
-using FezEngine.Tools;
+﻿using FezEngine.Tools;
 using FezGame.Services;
 using FezGame.Structure;
 using FezGame.Tools;
-using FezGame.Components;
 using FEZUG.Features.Console;
-using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Reflection;
-using FezGame;
 using Common;
 
 namespace FEZUG.Features
@@ -22,7 +10,7 @@ namespace FEZUG.Features
     internal static class Quicksaving
     {
         public static readonly string SaveDirectory = "QuickSaves";
-        
+
         public static string ValidateSaveFilePathOutOfArgs(string[] args)
         {
             if (args.Length != 1)
@@ -169,8 +157,7 @@ namespace FEZUG.Features
                 if (!Directory.Exists(quicksaveDir))
                     return null;
 
-                return Directory.GetFiles(quicksaveDir).Select(path => Path.GetFileName(path))
-                    .Where(name => name.StartsWith(args[0])).ToList();
+                return [.. Directory.GetFiles(quicksaveDir).Select(path => Path.GetFileName(path)).Where(name => name.StartsWith(args[0]))];
             }
         }
     }

--- a/Features/ReloadLevel.cs
+++ b/Features/ReloadLevel.cs
@@ -1,11 +1,6 @@
 ﻿using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {

--- a/Features/SpinningCubeHitboxDraw.cs
+++ b/Features/SpinningCubeHitboxDraw.cs
@@ -1,9 +1,6 @@
-﻿using FezEngine;
-using FezEngine.Components;
+﻿using FezEngine.Components;
 using FezEngine.Effects;
-using FezEngine.Services;
 using FezEngine.Structure;
-using FezEngine.Structure.Geometry;
 using FezEngine.Tools;
 using FezGame.Components;
 using FezGame.Services;
@@ -11,11 +8,6 @@ using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -65,7 +57,7 @@ namespace FEZUG.Features
                 Color c = trileColor;
                 TrileBoundingBox.AddWireframeBox(Vector3.One, Vector3.Zero, new Color(c.R, c.G, c.B, 32), true);
                 TrileBoundingBox.AddColoredBox(Vector3.One, Vector3.Zero, new Color(c.R, c.G, c.B, 32), true);
-                
+
             });
         }
 
@@ -103,7 +95,7 @@ namespace FEZUG.Features
 
             public List<string> Autocomplete(string[] args)
             {
-                return new string[] { "on", "off" }.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[] { "on", "off" }.Where(s => s.StartsWith(args[0]))];
             }
 
             public bool Execute(string[] args)

--- a/Features/StereoscopyToggle.cs
+++ b/Features/StereoscopyToggle.cs
@@ -13,7 +13,7 @@ namespace FEZUG.Features
 
         [ServiceDependency]
         public IGameStateManager GameState { private get; set; }
-        
+
 
         public StereoscopyToggle()
         {
@@ -22,7 +22,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-            return new string[] { "on", "off", "toggle" }.Where(s => s.StartsWith(args[0])).ToList();
+            return [.. new string[] { "on", "off", "toggle" }.Where(s => s.StartsWith(args[0]))];
         }
 
         public bool Execute(string[] args)

--- a/Features/Teleport.cs
+++ b/Features/Teleport.cs
@@ -3,12 +3,7 @@ using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -38,7 +33,7 @@ namespace FEZUG.Features
                 default: return null;
             }
 
-            return new List<string> { value.ToString("0.000", CultureInfo.InvariantCulture) };
+            return [value.ToString("0.000", CultureInfo.InvariantCulture)];
         }
 
         public bool Execute(string[] args)

--- a/Features/TimeSet.cs
+++ b/Features/TimeSet.cs
@@ -1,12 +1,7 @@
 ﻿using FezEngine.Services;
 using FezEngine.Tools;
 using FEZUG.Features.Console;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -23,21 +18,21 @@ namespace FEZUG.Features
         {
             if(args.Length == 1)
             {
-                return new string[] { "set", "speed" }.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[] { "set", "speed" }.Where(s => s.StartsWith(args[0]))];
             }else if(args.Length == 2)
             {
                 if (args[0].Equals("set"))
                 {
-                    return new string[]
+                    return [.. new string[]
                     {
                         TimeManager.CurrentTime.ToString("HH:mm"),
                         "dawn", "day", "dusk", "night", "real"
-                    }.Where(s => s.StartsWith(args[1])).ToList();
+                    }.Where(s => s.StartsWith(args[1]))];
                 }
                 if (args[0].Equals("speed") && args[1].Length == 0)
                 {
                     float curTime = TimeManager.TimeFactor / TimeManager.DefaultTimeFactor;
-                    return new List<string> { curTime.ToString("0.000", CultureInfo.InvariantCulture) , "real"};
+                    return [curTime.ToString("0.000", CultureInfo.InvariantCulture) , "real"];
                 }
             }
             return null;
@@ -68,7 +63,7 @@ namespace FEZUG.Features
                     }
                 }
                 TimeManager.CurrentTime = dateTime;
-                FezugConsole.Print($"Time has been set to {dateTime.ToString("H:mm")}.");
+                FezugConsole.Print($"Time has been set to {dateTime:H:mm}.");
             }
             else if(args[0] == "speed")
             {

--- a/Features/Timescaler.cs
+++ b/Features/Timescaler.cs
@@ -3,16 +3,9 @@ using FezEngine.Tools;
 using FezGame;
 using FEZUG.Features.Console;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Audio;
 using MonoMod.RuntimeDetour;
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -36,7 +29,7 @@ namespace FEZUG.Features
         public List<string> Autocomplete(string[] args)
         {
             string timescaleStr = Timescale.ToString("0.000", CultureInfo.InvariantCulture);
-            if (timescaleStr.StartsWith(args[0])) return new List<string> { timescaleStr };
+            if (timescaleStr.StartsWith(args[0])) return [timescaleStr];
             return null;
         }
 
@@ -68,14 +61,14 @@ namespace FEZUG.Features
 
             mainGameUpdateLoopDetour = new Hook(
                 typeof(Fez).GetMethod("Update", BindingFlags.NonPublic | BindingFlags.Instance),
-                (Action<Action<Fez, GameTime>, Fez, GameTime>)delegate (Action<Fez, GameTime> original, Fez self, GameTime gameTime)
+                delegate (Action<Fez, GameTime> original, Fez self, GameTime gameTime)
                 {
                     UpdateHooked(original, self, gameTime);
                 }
             );
             mainGameDrawLoopDetour = new Hook(
                 typeof(Fez).GetMethod("Draw", BindingFlags.NonPublic | BindingFlags.Instance),
-                (Action<Action<Fez, GameTime>, Fez, GameTime>)delegate (Action<Fez, GameTime> original, Fez self, GameTime gameTime)
+                delegate (Action<Fez, GameTime> original, Fez self, GameTime gameTime)
                 {
                     DrawHooked(original, self, gameTime);
                 }

--- a/Features/VolumeDraw.cs
+++ b/Features/VolumeDraw.cs
@@ -1,19 +1,12 @@
-﻿using FezEngine;
-using FezEngine.Effects;
+﻿using FezEngine.Effects;
 using FezEngine.Services;
 using FezEngine.Structure;
-using FezEngine.Structure.Geometry;
 using FezEngine.Tools;
 using FezGame.Services;
 using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -51,20 +44,20 @@ namespace FEZUG.Features
         {
             DrawActionScheduler.Schedule(delegate
             {
-                volumes = new Dictionary<int, VolumeType>();
+                volumes = [];
                 LevelManager.LevelChanged += RefreshVolumeList;
 
                 if (VolumeBoundingBoxes == null)
                 {
-                    Color[] volColors = new Color[]
-                    {
+                    Color[] volColors =
+                    [
                         Color.Black,
                         Color.Gold,
                         Color.Blue,
                         Color.Gray,
                         Color.Lime,
                         Color.Purple
-                    };
+                    ];
                     int VolTypeCount = volColors.Length;
                     VolumeBoundingBoxes = new Mesh[VolTypeCount];
 
@@ -82,9 +75,8 @@ namespace FEZUG.Features
                             DepthWrites = false,
                             Blending = BlendingMode.Alphablending,
                             Culling = CullMode.CullClockwiseFace,
+                            Effect = effect
                         };
-
-                        VolumeBoundingBoxes[i].Effect = effect;
 
                         Color c = volColors[i];
                         VolumeBoundingBoxes[i].AddWireframeBox(Vector3.One, Vector3.Zero, new Color(c.R, c.G, c.B, 255), true);
@@ -186,7 +178,7 @@ namespace FEZUG.Features
 
             public List<string> Autocomplete(string[] args)
             {
-                return new string[] { "on", "off", "xray" }.Where(s => s.StartsWith(args[0])).ToList();
+                return [.. new string[] { "on", "off", "xray" }.Where(s => s.StartsWith(args[0]))];
             }
 
             public bool Execute(string[] args)
@@ -205,7 +197,7 @@ namespace FEZUG.Features
 
                 bool xray = args[0] == "xray";
                 WireframesEnabled = xray || args[0] == "on";
-                foreach(var vol in VolumeBoundingBoxes) { 
+                foreach(var vol in VolumeBoundingBoxes) {
                     vol.AlwaysOnTop = xray;
                 }
                 FezugConsole.Print($"Volume wireframes have been {(WireframesEnabled ? "enabled" + (xray ? " in xray mode" : "") : "disabled")}.");

--- a/Features/VolumeInfo.cs
+++ b/Features/VolumeInfo.cs
@@ -1,9 +1,4 @@
-﻿using Common;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework;
-using FezGame.Services;
+﻿using FezGame.Services;
 using FezEngine.Tools;
 using FEZUG.Features.Console;
 
@@ -25,7 +20,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-		public List<string> Autocomplete(string[] _args) { return new List<string> { }; }
+		public List<string> Autocomplete(string[] _args) { return []; }
 
 		public bool Execute(string[] args)
 		{
@@ -40,7 +35,7 @@ namespace FEZUG.Features
                         FezugConsole.Print($"To: {volume.To}");
                         FezugConsole.Print($"Bounding Box: {volume.BoundingBox}");
                         FezugConsole.Print($"Enabled: {volume.Enabled}");
-                        FezugConsole.Print($"Orientations: {String.Join(", ", volume.Orientations.OrderBy(a=>a).ToArray())}");
+                        FezugConsole.Print($"Orientations: {string.Join(", ", volume.Orientations.OrderBy(a=>a).ToArray())}");
                         if (volume.ActorSettings != null)
                         {
                             var actorSettings = volume.ActorSettings;
@@ -66,7 +61,7 @@ namespace FEZUG.Features
                             }
                             if(actorSettings.CodePattern != null && actorSettings.CodePattern.Length > 0)
                             {
-                                FezugConsole.Print($"CodePattern: {String.Join(", ", actorSettings.CodePattern)}");
+                                FezugConsole.Print($"CodePattern: {string.Join(", ", actorSettings.CodePattern)}");
                             }
                         }
                         return true;
@@ -107,7 +102,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-        public List<string> Autocomplete(string[] _args) { return new List<string> { }; }
+        public List<string> Autocomplete(string[] _args) { return []; }
 
         public bool Execute(string[] args)
         {
@@ -128,7 +123,7 @@ namespace FEZUG.Features
             var Volume = LevelManager.Volumes[int.Parse(args[0])];
             PlayerManager.IgnoreFreefall = true;
             PlayerManager.Position = (Volume.From + Volume.To) / 2.0f;
-            return true; 
+            return true;
         }
     }
 }

--- a/Features/WarpLevel.cs
+++ b/Features/WarpLevel.cs
@@ -1,19 +1,12 @@
-﻿using Common;
-using FezEngine.Components;
+﻿using FezEngine.Components;
 using FezEngine.Services;
-using FezEngine.Services.Scripting;
 using FezEngine.Tools;
 using FezGame;
 using FezGame.Services;
 using FezGame.Structure;
 using FEZUG.Features.Console;
 using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {
@@ -33,9 +26,9 @@ namespace FEZUG.Features
         {
             get
             {
-				return MemoryContentManager.AssetNames
+				return [.. MemoryContentManager.AssetNames
 				.Where(s => s.ToLower().StartsWith($"levels\\"))
-				.Select(s => s.Substring("levels\\".Length)).ToList();
+				.Select(s => s.Substring("levels\\".Length))];
 			}
 		}
 
@@ -72,7 +65,7 @@ namespace FEZUG.Features
 			if(args.Length == 0)
             {
 				FezugConsole.Print("List of available levels:");
-				FezugConsole.Print(String.Join(", ", LevelList));
+				FezugConsole.Print(string.Join(", ", LevelList));
 				return true;
 			}
 
@@ -96,7 +89,7 @@ namespace FEZUG.Features
 			/* pre-warp safety measures */
 
 			// make sure no stuff from previous save remains after switching the save.
-			List<IWaiter> waitersToCancel = ServiceHelper.Game.Components.Where(comp => comp is IWaiter).Select(comp => comp as IWaiter).ToList();
+			List<IWaiter> waitersToCancel = [.. ServiceHelper.Game.Components.Where(comp => comp is IWaiter).Select(comp => comp as IWaiter)];
 			foreach (IWaiter waiter in waitersToCancel)
 			{
 				waiter.Cancel();
@@ -116,7 +109,7 @@ namespace FEZUG.Features
 					var TrackedCollectsField = SplitUpCubeHostType.GetField("TrackedCollects", BindingFlags.NonPublic | BindingFlags.Instance);
 					var TrackedCollects = TrackedCollectsField.GetValue(SplitUpCubeHost);
 					MethodInfo TrackedCollectsClear = TrackedCollects.GetType().GetMethod("Clear");
-					TrackedCollectsClear.Invoke(TrackedCollects, new object[] { });
+					TrackedCollectsClear.Invoke(TrackedCollects, []);
 				}
 			}
 
@@ -167,7 +160,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-			return LevelList.Where(s => s.ToLower().StartsWith($"{args[0]}")).ToList();
+			return [.. LevelList.Where(s => s.ToLower().StartsWith($"{args[0]}"))];
 		}
     }
 }

--- a/Features/Zoom.cs
+++ b/Features/Zoom.cs
@@ -1,20 +1,7 @@
-﻿using Common;
-using FezEngine.Components;
-using FezEngine.Services;
-using FezEngine.Services.Scripting;
+﻿using FezEngine.Services;
 using FezEngine.Tools;
-using FezGame;
-using FezGame.Services;
-using FezGame.Structure;
 using FEZUG.Features.Console;
-using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Features
 {

--- a/Helpers/DrawingTools.cs
+++ b/Helpers/DrawingTools.cs
@@ -28,7 +28,7 @@ namespace FEZUG.Helpers
                 DefaultFontSize = FontManager.BigFactor;
 
                 fillTexture = new Texture2D(GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
-                fillTexture.SetData(new[] { new Color(255, 255, 255) });
+                fillTexture.SetData([new Color(255, 255, 255)]);
             });
         }
 

--- a/Helpers/InputHelper.cs
+++ b/Helpers/InputHelper.cs
@@ -1,19 +1,12 @@
-﻿using FezEngine.Services;
-using FezEngine.Tools;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FEZUG.Helpers
 {
     internal static class InputHelper
     {
-        private static Dictionary<Keys, double> KeyboardRepeatHeldTimers = new Dictionary<Keys, double>();
-        private static List<Keys> KeyboardRepeatedPresses = new List<Keys>();
+        private static readonly Dictionary<Keys, double> KeyboardRepeatHeldTimers = [];
+        private static readonly List<Keys> KeyboardRepeatedPresses = [];
 
         public static KeyboardState CurrentKeyboardState { get; private set; }
         public static KeyboardState PreviousKeyboardState { get; private set; }
@@ -58,7 +51,7 @@ namespace FEZUG.Helpers
         {
             return PreviousKeyboardState.IsKeyDown(key) && CurrentKeyboardState.IsKeyUp(key);
         }
-        
+
         public static bool IsKeyTyped(Keys key)
         {
             return IsKeyPressed(key) || KeyboardRepeatedPresses.Contains(key);


### PR DESCRIPTION
Did a whole bunch of cleanup by removing redundant code (mainly Viewpoint from TextHud.cs), unused imports, using collections for some things, removing trailing whitespace and a few more opinionated stuff.

Didn't update FEZUG version since as far as I can tell, the commit that updated it for the stereoscopy command hasn't been released so this can be packaged in.

I've tested all the commands in game, but then again, I could have missed something subtle. Ultimately a lot of this is just from the Microsoft C# Dev Kit tooling that pointed out some stuff.