### PR TITLE
Use LangVersion 11.0 and fix booting on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,7 +297,7 @@ node_modules/
 *.dsw
 *.dsp
 
-# Visual Studio 6 technical files 
+# Visual Studio 6 technical files
 *.ncb
 *.aps
 

--- a/FEZUG.cs
+++ b/FEZUG.cs
@@ -32,17 +32,26 @@ namespace FEZUG
             DrawingTools.Init();
 
             Features = new();
-            foreach (Type type in Assembly.GetExecutingAssembly().GetTypes()
-            .Where(t => t.IsClass && typeof(IFezugFeature).IsAssignableFrom(t) && !t.IsAbstract))
-            {
-                IFezugFeature feature = (IFezugFeature)Activator.CreateInstance(type);
-                ServiceHelper.InjectServices(feature);
-                Features.Add(feature);
-            }
 
-            foreach (var feature in Features)
-            {
-                feature.Initialize();
+            try {
+                Type[] types = Assembly.GetExecutingAssembly().GetTypes();
+                foreach (Type type in types.Where(t => t.IsClass && typeof(IFezugFeature).IsAssignableFrom(t) && !t.IsAbstract))
+                {
+                    IFezugFeature feature = (IFezugFeature)Activator.CreateInstance(type);
+                    ServiceHelper.InjectServices(feature);
+                    Features.Add(feature);
+                }
+
+                foreach (var feature in Features)
+                {
+                    feature.Initialize();
+                }
+            } catch (ReflectionTypeLoadException e) {
+                string message = "Error while attempting to load types in this assembly!!! The classes in the following error messages are the ones with issues:\n";
+                foreach (Exception ex in e.LoaderExceptions) {
+                    message += "\n" + ex.Message;
+                }
+                throw new Exception(message);
             }
         }
 

--- a/FEZUG.cs
+++ b/FEZUG.cs
@@ -31,7 +31,7 @@ namespace FEZUG
 
             DrawingTools.Init();
 
-            Features = [];
+            Features = new();
             foreach (Type type in Assembly.GetExecutingAssembly().GetTypes()
             .Where(t => t.IsClass && typeof(IFezugFeature).IsAssignableFrom(t) && !t.IsAbstract))
             {

--- a/FEZUG.csproj
+++ b/FEZUG.csproj
@@ -4,9 +4,9 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    
+
     <ImplicitUsings>enable</ImplicitUsings>
-    
+
     <DebugType>full</DebugType>
   </PropertyGroup>
 

--- a/FEZUG.csproj
+++ b/FEZUG.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11.0</LangVersion>
 
     <ImplicitUsings>enable</ImplicitUsings>
 

--- a/Features/ArtObjectInfo.cs
+++ b/Features/ArtObjectInfo.cs
@@ -21,7 +21,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-		public List<string> Autocomplete(string[] _args) { return []; }
+		public List<string> Autocomplete(string[] _args) { return new(); }
 
 		public bool Execute(string[] args)
 		{
@@ -163,7 +163,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-        public List<string> Autocomplete(string[] _args) { return []; }
+        public List<string> Autocomplete(string[] _args) { return new(); }
 
         public bool Execute(string[] args)
         {

--- a/Features/ArtifactItemSet.cs
+++ b/Features/ArtifactItemSet.cs
@@ -14,25 +14,25 @@ namespace FEZUG.Features
         [ServiceDependency]
         public IGameStateManager GameState { private get; set; }
 
-        public readonly ActorType[] AllowedActorTypes =
-        [
+        public readonly ActorType[] AllowedActorTypes = new ActorType[]
+        {
             ActorType.Tome,
             ActorType.TriSkull,
             ActorType.LetterCube,
             ActorType.NumberCube
-        ];
+        };
 
         public List<string> Autocomplete(string[] args)
         {
             if (args.Length == 1)
             {
-                return [.. new string[] { "give", "remove", "list" }.Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))];
+                return new string[] { "give", "remove", "list" }.Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase)).ToList();
             }
             if (args.Length == 2)
             {
-                return [.. AllowedActorTypes
+                return AllowedActorTypes
                     .Select(s => s.ToString().ToLower())
-                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase))];
+                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase)).ToList();
             }
             return null;
         }

--- a/Features/BindingSystem.cs
+++ b/Features/BindingSystem.cs
@@ -28,7 +28,7 @@ namespace FEZUG.Features
         public BindingSystem()
         {
             Instance = this;
-            Binds = [];
+            Binds = new();
         }
 
         public void Initialize() {
@@ -92,7 +92,7 @@ namespace FEZUG.Features
             var bindFileLines = File.ReadAllLines(bindFilePath);
             foreach(var line in bindFileLines)
             {
-                string[] tokens = line.Split([' '], 2);
+                string[] tokens = line.Split(new char[] {' '}, 2);
                 if (tokens.Length < 2) continue;
 
                 if(TryParseBindName(tokens[0], out Keys key))
@@ -122,7 +122,7 @@ namespace FEZUG.Features
         }
         private static List<string> GetAutoCompleteOptions(string arg)
         {
-            return [..Enum.GetNames(typeof(Keys)).Select(s => s.ToLower()).Concat(Enum.GetNames(typeof(Buttons)).Select(b => GamePadPrefix + b)).Where(s => s.StartsWith(arg, StringComparison.OrdinalIgnoreCase))] ;
+            return Enum.GetNames(typeof(Keys)).Select(s => s.ToLower()).Concat(Enum.GetNames(typeof(Buttons)).Select(b => GamePadPrefix + b)).Where(s => s.StartsWith(arg, StringComparison.OrdinalIgnoreCase)).ToList();
         }
         private static bool TryParseBindName(string str, out Keys key)
         {
@@ -160,7 +160,7 @@ namespace FEZUG.Features
                 if (args.Length == 2 && Enum.TryParse<Keys>(args[0], true, out var key)
                 && HasBind(key) && GetBind(key).StartsWith(args[1], StringComparison.OrdinalIgnoreCase))
                 {
-                    return [GetBind(key)];
+                    return new() {GetBind(key)};
                 }
                 return null;
             }

--- a/Features/BindingSystem.cs
+++ b/Features/BindingSystem.cs
@@ -17,7 +17,7 @@ namespace FEZUG.Features
         private const int GamePadKeysOffset = 0x300000;
 
         private InputHelper InputHelper { get; } = InputHelper.Instance;
-        
+
         public BindList Binds { get; private set; }
 
         public static BindingSystem Instance;
@@ -68,8 +68,6 @@ namespace FEZUG.Features
             if (command.Length > 0)
                 Instance.Binds.Add(key, command);
 
-
-            string configPath = Path.Combine(Util.LocalConfigFolder, BindConfigFileName);
             SaveBinds();
         }
 

--- a/Features/BlackHoleManip.cs
+++ b/Features/BlackHoleManip.cs
@@ -33,7 +33,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-            return [.. new string[] { "on", "off", "lock", "unlock" }.Where(s => s.StartsWith(args[0]))];
+            return new string[] { "on", "off", "lock", "unlock" }.Where(s => s.StartsWith(args[0])).ToList();
         }
 
         public bool Execute(string[] args)

--- a/Features/BlackHoleManip.cs
+++ b/Features/BlackHoleManip.cs
@@ -73,7 +73,7 @@ namespace FEZUG.Features
 
         private bool AreBlackHolesEnabled()
         {
-            var blackHole = LevelManager.Volumes.Values.Where((Volume x) => x.ActorSettings != null && x.ActorSettings.IsBlackHole);
+            var blackHole = LevelManager.Volumes.Values.Where(x => x.ActorSettings != null && x.ActorSettings.IsBlackHole);
             if (blackHole.Count() == 0) return false;
             return blackHole.First().Enabled;
         }

--- a/Features/Console/CommandHelp.cs
+++ b/Features/Console/CommandHelp.cs
@@ -26,9 +26,9 @@
                 var helpStrings = new List<string>();
                 helpStrings.AddRange(cmdList.Select(cmd => cmd.HelpText));
                 helpStrings.AddRange(varList.Select(var => $"{var.Name} - {var.HelpText}"));
-                helpStrings = [.. helpStrings
-                    .SelectMany(str => str.Split(['\n']))
-                    .OrderBy(str => str)];
+                helpStrings = helpStrings
+                    .SelectMany(str => str.Split(new[] {'\n'}))
+                    .OrderBy(str => str).ToList();
 
                 int pageCount = (int)Math.Ceiling(helpStrings.Count / (float)CommandListPageSize);
                 pageNumber = Math.Min(Math.Max(pageNumber, 1), pageCount);

--- a/Features/Console/FezugConsole.cs
+++ b/Features/Console/FezugConsole.cs
@@ -14,7 +14,7 @@ namespace FEZUG.Features.Console
         public class ParsedCommand : List<string>
         {
             public string Command => this.Count() == 0 ? "" : this[0];
-            public string[] Arguments => this.Count() <= 1 ? [] : [.. this.Skip(1)];
+            public string[] Arguments => this.Count() <= 1 ? new string[0] : this.Skip(1).ToArray();
         }
 
         public class ParsedCommandSequence : List<ParsedCommand>
@@ -63,7 +63,7 @@ namespace FEZUG.Features.Console
                     if (endOfCommand)
                     {
                         Add(currentTokens);
-                        currentTokens = [];
+                        currentTokens = new();
                     }
 
                     if (quote)
@@ -107,7 +107,7 @@ namespace FEZUG.Features.Console
             {
                 ConsoleLine = consoleLine;
 
-                SuggestedWords = [""];
+                SuggestedWords = new() {""};
                 previousCommandSequence = new ParsedCommandSequence("");
             }
 
@@ -141,8 +141,8 @@ namespace FEZUG.Features.Console
                 // only one word in current command - autocomplete from all available commands and variables
                 if (command.Count == 1)
                 {
-                    SuggestedWords.AddRange([.. matchingCommands.Select(c => c.Name)]);
-                    SuggestedWords.AddRange([.. matchingVariables.Select(c => $"{c.Name} {c.ValueString}")]);
+                    SuggestedWords.AddRange(matchingCommands.Select(c => c.Name));
+                    SuggestedWords.AddRange(matchingVariables.Select(c => $"{c.Name} {c.ValueString}"));
                 }
                 // more than one words - get a command-specific or variable-specific autocompletion
                 else if(command.Count > 1)
@@ -238,7 +238,7 @@ namespace FEZUG.Features.Console
 
                 TextInputEXT.TextInput += OnTextInput;
 
-                Commands = [];
+                Commands = new();
                 foreach (Type type in Assembly.GetExecutingAssembly().GetTypes()
                 .Where(t => t.IsClass && typeof(IFezugCommand).IsAssignableFrom(t) && !t.IsAbstract && t.GetConstructor(Type.EmptyTypes) != null))
                 {
@@ -261,7 +261,7 @@ namespace FEZUG.Features.Console
                 Enabled = false;
                 Buffer = "";
 
-                previousBufferInputs = [];
+                previousBufferInputs = new();
 
                 Autocompletion = new AutocompletionManager(this);
                 BufferChanged += Autocompletion.Refresh;
@@ -571,7 +571,7 @@ namespace FEZUG.Features.Console
         };
 
         //Note: this is a ConcurrentQueue for thread safety, just in case another mod wants to use a separate thread to write to the console
-        private readonly ConcurrentQueue<ConsoleOutput> outputBuffer = [];
+        private readonly ConcurrentQueue<ConsoleOutput> outputBuffer = new();
         private float blinkingTime;
         private int previousCursor = 0;
 
@@ -635,7 +635,7 @@ namespace FEZUG.Features.Console
 
         public static void Print(string text, Color color)
         {
-            foreach(var splitText in text.Split(['\n']))
+            foreach(var splitText in text.Split(new[] {'\n'}))
             {
                 Instance.Print(new ConsoleOutput
                 {
@@ -728,7 +728,7 @@ namespace FEZUG.Features.Console
             var outputItemPos = 0;
             foreach (var outputLine in outputBuffer.Reverse())
             {
-                List<string> lines = [];
+                List<string> lines = new();
                 string lineBuffer = "";
                 foreach(var word in outputLine.Text.Split(' '))
                 {

--- a/Features/Console/FezugConsole.cs
+++ b/Features/Console/FezugConsole.cs
@@ -571,7 +571,7 @@ namespace FEZUG.Features.Console
         };
 
         //Note: this is a ConcurrentQueue for thread safety, just in case another mod wants to use a separate thread to write to the console
-        private ConcurrentQueue<ConsoleOutput> outputBuffer = [];
+        private readonly ConcurrentQueue<ConsoleOutput> outputBuffer = [];
         private float blinkingTime;
         private int previousCursor = 0;
 
@@ -610,7 +610,7 @@ namespace FEZUG.Features.Console
         public void UnfixedUpdate(GameTime gameTime)
         {
             var unscaledTime = Timescaler.GetUnscaledGameTime(gameTime);
-            
+
             Handler.Update(unscaledTime);
 
             if (!Handler.Enabled) return;
@@ -658,7 +658,7 @@ namespace FEZUG.Features.Console
         public void DrawHUD(GameTime gameTime)
         {
             UnfixedUpdate(gameTime);
-            
+
             if (!Handler.Enabled) return;
 
             Viewport viewport = DrawingTools.GetViewport();

--- a/Features/Console/FezugVariable.cs
+++ b/Features/Console/FezugVariable.cs
@@ -7,7 +7,7 @@ namespace FEZUG.Features.Console
     {
         public const string VariablesFileName = "FezugVars";
 
-        public static List<FezugVariable> DefinedList { get; private set; } = [];
+        public static List<FezugVariable> DefinedList { get; private set; } = new();
         private static Dictionary<string, string> LoadedVariables { get; set; }
 
         public readonly string Name;
@@ -130,14 +130,14 @@ namespace FEZUG.Features.Console
         private static void LoadVariables()
         {
             if (LoadedVariables != null) return;
-            LoadedVariables = [];
+            LoadedVariables = new();
 
             var varsFilePath = GetVariablesFilePath();
             if (!File.Exists(varsFilePath)) return;
             var varsFileLines = File.ReadAllLines(varsFilePath);
             foreach (var line in varsFileLines)
             {
-                string[] tokens = line.Split([' '], 2);
+                string[] tokens = line.Split(new char[] {' '}, 2);
                 if (tokens.Length < 2) continue;
 
                 LoadedVariables[tokens[0]] = tokens[1];

--- a/Features/Console/GenericFezugCommand.cs
+++ b/Features/Console/GenericFezugCommand.cs
@@ -7,13 +7,13 @@ namespace FEZUG.Features.Console
 
         public string HelpText { get; }
 
-        private Func<string[], List<string>> AutocompleteProvider;
+        private readonly Func<string[], List<string>> AutocompleteProvider;
         public List<string> Autocomplete(string[] args)
         {
             return AutocompleteProvider(args);
         }
 
-        private Func<string[], bool> ExecuteCommand;
+        private readonly Func<string[], bool> ExecuteCommand;
         public bool Execute(string[] args)
         {
             return ExecuteCommand(args);

--- a/Features/Console/GenericFezugCommand.cs
+++ b/Features/Console/GenericFezugCommand.cs
@@ -23,7 +23,7 @@ namespace FEZUG.Features.Console
         {
             this.Name = name;
             this.HelpText = helpText;
-            AutocompleteProvider = autocompleteProvider ?? (_ => []);
+            AutocompleteProvider = autocompleteProvider ?? (_ => new());
             ExecuteCommand = executeCommand ?? (_ => false);
         }
     }

--- a/Features/FullBright.cs
+++ b/Features/FullBright.cs
@@ -24,7 +24,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-            return [.. new[] { "on", "off" }.Where(s => s.StartsWith(args[0]))];
+            return new[] { "on", "off" }.Where(s => s.StartsWith(args[0])).ToList();
         }
 
         public bool Execute(string[] args)

--- a/Features/GetTrileInfo.cs
+++ b/Features/GetTrileInfo.cs
@@ -34,7 +34,7 @@ namespace FEZUG.Features
             default: return null;
             }
 
-            return [value.ToString("0", CultureInfo.InvariantCulture)];
+            return new() {value.ToString("0", CultureInfo.InvariantCulture)};
         }
 
 

--- a/Features/GetTrileInfo.cs
+++ b/Features/GetTrileInfo.cs
@@ -40,7 +40,7 @@ namespace FEZUG.Features
 
         public bool Execute(string[] args)
         {
-            if (!Teleport.TryParseCoords(args, 
+            if (!Teleport.TryParseCoords(args,
                 PlayerManager.Ground.First?.Emplacement.AsVector ?? PlayerManager.Position.Round(),
                 out Vector3 coords))
             {

--- a/Features/GomezHitboxDraw.cs
+++ b/Features/GomezHitboxDraw.cs
@@ -17,7 +17,7 @@ namespace FEZUG.Features
 
         protected override Mesh[] RefreshBoundingBoxMeshs()
         {
-            return [GomezBoundingBox = CreateHitboxMesh(Color.Red)];
+            return new Mesh[] {GomezBoundingBox = CreateHitboxMesh(Color.Red)};
         }
 
         public override void DrawLevel(GameTime gameTime)

--- a/Features/Hud/FpsGraph.cs
+++ b/Features/Hud/FpsGraph.cs
@@ -11,7 +11,7 @@ namespace FEZUG.Features.Hud
 {
     public class FpsGraph : IFezugFeature
     {
-        private readonly Dictionary<string, (FezugVariable fezugVar, Color lineColor, List<double> pastVals)> graphVars = [];
+        private readonly Dictionary<string, (FezugVariable fezugVar, Color lineColor, List<double> pastVals)> graphVars = new();
         private FezugVariable hud_graph_hide, graph_maxcount, graph_interval;
 
         private HudPositioner Positioner;
@@ -39,7 +39,7 @@ namespace FEZUG.Features.Hud
                     SaveOnChange = true,
                     Min = 0,
                     Max = 1
-                }, lineColor, []));
+                }, lineColor, new()));
             }
 
             CreateGraphVariable("ups", "graph_ups", "updates per second", Color.Cyan);

--- a/Features/Hud/FpsGraph.cs
+++ b/Features/Hud/FpsGraph.cs
@@ -86,7 +86,7 @@ namespace FEZUG.Features.Hud
             double elapsedSeconds = (DateTime.Now - _lastTime).TotalSeconds;
             if (elapsedSeconds >= intervalSeconds)
             {
-                // one second has elapsed 
+                // one second has elapsed
                 _fps = _framesRendered;
                 _framesRendered = 0;
                 _ups = _updatesDone;
@@ -164,7 +164,7 @@ namespace FEZUG.Features.Hud
                     float avg = (float)pastVals.Average();
                     float avgPosY = yOff + avg * yScale;
                     //draw average
-                    Vector2 avgTextPos = new Vector2(xOff, yOff + textHeight * (enabledCount - 1 - displayTextIndex));
+                    Vector2 avgTextPos = new(xOff, yOff + textHeight * (enabledCount - 1 - displayTextIndex));
                     DrawingTools.DrawLineSegment(new(xOff, avgPosY), new(xOff + width, avgPosY), avgLineColor, lineThickness);
                     DrawingTools.DrawText(pair.Key.ToUpper() + " (avg): " + avg, avgTextPos, avgLineColor);
                     ++displayTextIndex;

--- a/Features/Hud/FpsGraph.cs
+++ b/Features/Hud/FpsGraph.cs
@@ -11,7 +11,7 @@ namespace FEZUG.Features.Hud
 {
     public class FpsGraph : IFezugFeature
     {
-        private readonly Dictionary<string, (FezugVariable fezugVar, Color lineColor, List<double> pastVals)> graphVars = new();
+        private readonly Dictionary<string, GraphVar> graphVars = new();
         private FezugVariable hud_graph_hide, graph_maxcount, graph_interval;
 
         private HudPositioner Positioner;
@@ -34,7 +34,7 @@ namespace FEZUG.Features.Hud
         {
             void CreateGraphVariable(string id, string name, string desc, Color lineColor)
             {
-                graphVars.Add(id, (new FezugVariable(name, $"If set, enables {desc} graph hud.", "0")
+                graphVars.Add(id, new GraphVar(new FezugVariable(name, $"If set, enables {desc} graph hud.", "0")
                 {
                     SaveOnChange = true,
                     Min = 0,
@@ -143,25 +143,25 @@ namespace FEZUG.Features.Hud
             int displayTextIndex = 0;
             foreach (var pair in varsForDrawing)
             {
-                var (fezugVar, lineColor, pastVals) = pair.Value;
-                if (fezugVar.ValueBool && pastVals.Count > 1)
+                var graphVar = pair.Value;
+                if (graphVar.fezugVar.ValueBool && graphVar.pastVals.Count > 1)
                 {
-                    var avgLineColor = Color.Multiply(lineColor, avgLineColorAdjust);
+                    var avgLineColor = Color.Multiply(graphVar.lineColor, avgLineColorAdjust);
                     avgLineColor.A /= 2;
-                    float max = (float)pastVals.Max();
-                    var xScale = (width - padding) / (pastVals.Count - 1);
+                    float max = (float)graphVar.pastVals.Max();
+                    var xScale = (width - padding) / (graphVar.pastVals.Count - 1);
                     var yScale = (height - padding) / max;
-                    Vector2 previousPoint = boxTopLeft + new Vector2(0, yScale * (float)pastVals[0]);
-                    for (int i=1; i<pastVals.Count; ++i)
+                    Vector2 previousPoint = boxTopLeft + new Vector2(0, yScale * (float)graphVar.pastVals[0]);
+                    for (int i=1; i<graphVar.pastVals.Count; ++i)
                     {
                         //draw line in box
-                        Vector2 nextPoint = boxTopLeft + new Vector2(xScale * i, (float)(yScale * pastVals[i]));
-                        DrawingTools.DrawLineSegment(previousPoint, nextPoint, lineColor, lineThickness);
+                        Vector2 nextPoint = boxTopLeft + new Vector2(xScale * i, (float)(yScale * graphVar.pastVals[i]));
+                        DrawingTools.DrawLineSegment(previousPoint, nextPoint, graphVar.lineColor, lineThickness);
                         //draw line joints / nodes
                         //DrawingTools.DrawRect(new Rectangle((int)point1.X + lineThickness, (int)point1.Y, lineThickness, lineThickness), lineColor);
                         previousPoint = nextPoint;
                     }
-                    float avg = (float)pastVals.Average();
+                    float avg = (float)graphVar.pastVals.Average();
                     float avgPosY = yOff + avg * yScale;
                     //draw average
                     Vector2 avgTextPos = new(xOff, yOff + textHeight * (enabledCount - 1 - displayTextIndex));
@@ -169,6 +169,20 @@ namespace FEZUG.Features.Hud
                     DrawingTools.DrawText(pair.Key.ToUpper() + " (avg): " + avg, avgTextPos, avgLineColor);
                     ++displayTextIndex;
                 }
+            }
+        }
+
+        internal class GraphVar
+        {
+            internal FezugVariable fezugVar;
+            internal Color lineColor;
+            internal List<double> pastVals;
+
+            internal GraphVar(FezugVariable fezugVar, Color lineColor, List<double> pastVals)
+            {
+                this.fezugVar = fezugVar;
+                this.lineColor = lineColor;
+                this.pastVals = pastVals;
             }
         }
     }

--- a/Features/Hud/TextHud.cs
+++ b/Features/Hud/TextHud.cs
@@ -130,7 +130,7 @@ namespace FEZUG.Features.Hud
             _framesRendered++;
             if ((DateTime.Now - _lastTime).TotalSeconds >= 1)
             {
-                // one second has elapsed 
+                // one second has elapsed
 
                 _fps = _framesRendered;
                 _framesRendered = 0;

--- a/Features/Hud/TextHud.cs
+++ b/Features/Hud/TextHud.cs
@@ -11,7 +11,7 @@ namespace FEZUG.Features.Hud
 {
     public class TextHud : IFezugFeature
     {
-        private readonly List<(FezugVariable var, Func<string> provider)> hudVars = new();
+        private readonly List<HudVariable> hudVars = new();
 
         private FezugVariable hud_hide;
 
@@ -38,7 +38,7 @@ namespace FEZUG.Features.Hud
         {
             void CreateHudVariable(string name, string desc, Func<string> provider)
             {
-                hudVars.Add((new FezugVariable(name, $"If set, enables {desc} text hud.", "0")
+                hudVars.Add(new HudVariable(new FezugVariable(name, $"If set, enables {desc} text hud.", "0")
                 {
                     SaveOnChange = true,
                     Min = 0,
@@ -151,11 +151,11 @@ namespace FEZUG.Features.Hud
                 $"FEZUG {Fezug.Version}"
             };
 
-            foreach (var (var, provider) in hudVars)
+            foreach (var hudVar in hudVars)
             {
-                if(var.ValueBool)
+                if(hudVar.var.ValueBool)
                 {
-                    linesToDraw.Add(provider());
+                    linesToDraw.Add(hudVar.provider());
                 }
             }
 
@@ -182,6 +182,18 @@ namespace FEZUG.Features.Hud
                 if (i == 0) DrawText(line, position + new Vector2(padX, (i*30.0f)-1.0f));
             }
 
+        }
+
+        internal class HudVariable
+        {
+            internal FezugVariable var;
+            internal Func<string> provider;
+
+            internal HudVariable(FezugVariable var, Func<string> provider)
+            {
+                this.var = var;
+                this.provider = provider;
+            }
         }
     }
 }

--- a/Features/Hud/TextHud.cs
+++ b/Features/Hud/TextHud.cs
@@ -11,7 +11,7 @@ namespace FEZUG.Features.Hud
 {
     public class TextHud : IFezugFeature
     {
-        private readonly List<(FezugVariable var, Func<string> provider)> hudVars = [];
+        private readonly List<(FezugVariable var, Func<string> provider)> hudVars = new();
 
         private FezugVariable hud_hide;
 

--- a/Features/InvisibleTrilesDraw.cs
+++ b/Features/InvisibleTrilesDraw.cs
@@ -1,13 +1,8 @@
 ﻿using FezEngine;
-using FezEngine.Effects;
-using FezEngine.Services;
 using FezEngine.Structure;
 using FezEngine.Tools;
-using FezGame.Services;
-using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 
 namespace FEZUG.Features
 {
@@ -28,7 +23,7 @@ namespace FEZUG.Features
         }
 
         private Group oneFaceGroup;
-        private Dictionary<TrileEmplacement, InvisibleType> invisibleTriles = [];
+        private readonly Dictionary<TrileEmplacement, InvisibleType> invisibleTriles = [];
 
         private Mesh[] TrileBoundingBoxes;
 

--- a/Features/InvisibleTrilesDraw.cs
+++ b/Features/InvisibleTrilesDraw.cs
@@ -23,18 +23,18 @@ namespace FEZUG.Features
         }
 
         private Group oneFaceGroup;
-        private readonly Dictionary<TrileEmplacement, InvisibleType> invisibleTriles = [];
+        private readonly Dictionary<TrileEmplacement, InvisibleType> invisibleTriles = new();
 
         private Mesh[] TrileBoundingBoxes;
 
         protected override Mesh[] RefreshBoundingBoxMeshs()
         {
-            Color[] trileColors =
-            [
+            Color[] trileColors = new Color[]
+            {
                 Color.Gray,
                 Color.White,
                 Color.Magenta
-            ];
+            };
             int colorCount = trileColors.Length;
             TrileBoundingBoxes = new Mesh[3];
             for (var i = 0; i < colorCount; i++)

--- a/Features/ItemCountSet.cs
+++ b/Features/ItemCountSet.cs
@@ -24,7 +24,7 @@ namespace FEZUG.Features
             }
 
             int.TryParse(args[1], out var amount);
-            string itemName = "";
+            string itemName;
 
             switch (args[0])
             {

--- a/Features/ItemCountSet.cs
+++ b/Features/ItemCountSet.cs
@@ -66,7 +66,7 @@ namespace FEZUG.Features
         {
             if(args.Length == 1)
             {
-                return [.. new string[]{ "goldens", "antis", "bits", "hearts", "keys", "owls"}.Where(s => s.StartsWith(args[0]))];
+                return new string[]{ "goldens", "antis", "bits", "hearts", "keys", "owls"}.Where(s => s.StartsWith(args[0])).ToList();
             }
             else if(args.Length == 2 && args[1].Length == 0)
             {
@@ -86,7 +86,7 @@ namespace FEZUG.Features
                     case "owls":
                         value = GameState.SaveData.CollectedOwls; break;
                 }
-                return [value.ToString()];
+                return new() {value.ToString()};
             }
             return null;
         }

--- a/Features/LevelTimer.cs
+++ b/Features/LevelTimer.cs
@@ -24,7 +24,7 @@ namespace FEZUG.Features
         private string endLevel = "";
 
         private TimeSpan lastTime = TimeSpan.Zero;
-        private readonly List<TimeSpan> timeHistory = [];
+        private readonly List<TimeSpan> timeHistory = new();
 
 
         private string lastTimerString = "THIS IS A TEST";

--- a/Features/MapItemSet.cs
+++ b/Features/MapItemSet.cs
@@ -16,23 +16,23 @@ namespace FEZUG.Features
 
         public List<string> GetMapList()
         {
-            return [.. MemoryContentManager.AssetNames
+            return MemoryContentManager.AssetNames
                 .Where(s => s.ToLower().StartsWith("other textures\\maps\\"))
                 .Select(s => Regex.Match(s.ToUpper(), @".*\\(.*?)(?:_\d+.*)").Groups[1].Value)
-                .Distinct()];
+                .Distinct().ToList();
         }
 
         public List<string> Autocomplete(string[] args)
         {
             if(args.Length == 1)
             {
-                return [.. new string[] { "give", "remove", "list" }.Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase))];
+                return new string[] { "give", "remove", "list" }.Where(s => s.StartsWith(args[0], StringComparison.OrdinalIgnoreCase)).ToList();
             }
             if(args.Length == 2)
             {
-                return [.. GetMapList()
+                return GetMapList()
                     .Select(s=>s.ToLower())
-                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase))];
+                    .Where(s => s.StartsWith(args[1], StringComparison.OrdinalIgnoreCase)).ToList();
             }
             return null;
         }

--- a/Features/ProgressSet.cs
+++ b/Features/ProgressSet.cs
@@ -16,11 +16,11 @@ namespace FEZUG.Features
         [ServiceDependency]
         public IGameLevelManager LevelManager { private get; set; }
 
-        public List<string> AllowedFlagNames =
-        [
+        public List<string> AllowedFlagNames = new()
+        {
             "CanNewGamePlus", "IsNewGamePlus", "Finished32", "Finished64", "HasFPView", "HasStereo3D", "HasDoneHeartReboot",
             "FezHidden", "HasHadMapHelp", "CanOpenMap", "AchievementCheatCodeDone", "MapCheatCodeDone", "AnyCodeDeciphered",
-        ];
+        };
 
         public bool Execute(string[] args)
         {
@@ -216,25 +216,25 @@ namespace FEZUG.Features
         {
             if (args.Length == 1)
             {
-                return [.. new string[] { "flag", "level", "all" }.Where(s => s.StartsWith(args[0]))];
+                return new string[] { "flag", "level", "all" }.Where(s => s.StartsWith(args[0])).ToList();
             }
             else if (args.Length == 3 || args[0] == "all")
             {
-                return [.. new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[args.Length-1]))];
+                return new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[args.Length-1])).ToList();
             }
             else if (args.Length == 2)
             {
                 if (args[0] == "level")
                 {
-                    var list = WarpLevel.Instance.Autocomplete([args[1]]);
+                    var list = WarpLevel.Instance.Autocomplete(new string[] {args[1]});
                     list.AddRange(
-                        [.. new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[1]))]
+                        new string[] { "unlock", "reset" }.Where(s => s.StartsWith(args[1]))
                     );
                     return list;
                 }
                 else if (args[0] == "flag")
                 {
-                    return [.. AllowedFlagNames.Where(s => s.StartsWith(args[1]))];
+                    return AllowedFlagNames.Where(s => s.StartsWith(args[1])).ToList();
                 }
             }
 

--- a/Features/Quicksave.cs
+++ b/Features/Quicksave.cs
@@ -103,7 +103,7 @@ namespace FEZUG.Features
             {
                 if (args.Length == 0)
                 {
-                    List<string> paths = Autocomplete([""]);
+                    List<string> paths = Autocomplete(new string[] {""});
                     if (paths == null || paths.Count == 0)
                     {
                         FezugConsole.Print("No available quicksaves");
@@ -157,7 +157,7 @@ namespace FEZUG.Features
                 if (!Directory.Exists(quicksaveDir))
                     return null;
 
-                return [.. Directory.GetFiles(quicksaveDir).Select(path => Path.GetFileName(path)).Where(name => name.StartsWith(args[0]))];
+                return Directory.GetFiles(quicksaveDir).Select(path => Path.GetFileName(path)).Where(name => name.StartsWith(args[0])).ToList();
             }
         }
     }

--- a/Features/SettingsCommands.cs
+++ b/Features/SettingsCommands.cs
@@ -74,7 +74,6 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-            
             string valStr = Value.ToString(numFormatString, CultureInfo.InvariantCulture);
             if (valStr.StartsWith(args[0])) return new List<string> { valStr };
             return null;

--- a/Features/SpinningCubeHitboxDraw.cs
+++ b/Features/SpinningCubeHitboxDraw.cs
@@ -1,13 +1,9 @@
 ﻿using FezEngine.Components;
-using FezEngine.Effects;
 using FezEngine.Structure;
 using FezEngine.Tools;
 using FezGame.Components;
-using FezGame.Services;
-using FEZUG.Features.Console;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 
 namespace FEZUG.Features
 {
@@ -31,7 +27,7 @@ namespace FEZUG.Features
         protected override void PreInitialize()
         {
             System.Reflection.FieldInfo spinTreasureField = typeof(FezGame.Fez).Assembly.GetType("FezGame.Components.SpinningTreasuresHost").GetField("TrackedTreasures", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-            Func<SpinningTreasuresHost> getSpinningTreasuresHost = () => (SpinningTreasuresHost)ServiceHelper.Game.Components.FirstOrDefault(c => typeof(SpinningTreasuresHost).Equals(c.GetType()));
+            static SpinningTreasuresHost getSpinningTreasuresHost() => (SpinningTreasuresHost)ServiceHelper.Game.Components.FirstOrDefault(c => typeof(SpinningTreasuresHost).Equals(c.GetType()));
             Waiters.Wait(() => getSpinningTreasuresHost() != null, () =>
             {
                 SpinningTreasuresHost spinningTreasureHost = getSpinningTreasuresHost();

--- a/Features/SpinningCubeHitboxDraw.cs
+++ b/Features/SpinningCubeHitboxDraw.cs
@@ -22,7 +22,7 @@ namespace FEZUG.Features
 
         protected override Mesh[] RefreshBoundingBoxMeshs()
         {
-            return [TrileBoundingBox = CreateHitboxMesh(Color.Gold)];
+            return new Mesh[] {TrileBoundingBox = CreateHitboxMesh(Color.Gold)};
         }
         protected override void PreInitialize()
         {

--- a/Features/StereoscopyToggle.cs
+++ b/Features/StereoscopyToggle.cs
@@ -22,7 +22,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-            return [.. new string[] { "on", "off", "toggle" }.Where(s => s.StartsWith(args[0]))];
+            return new string[] { "on", "off", "toggle" }.Where(s => s.StartsWith(args[0])).ToList();
         }
 
         public bool Execute(string[] args)

--- a/Features/Teleport.cs
+++ b/Features/Teleport.cs
@@ -33,7 +33,7 @@ namespace FEZUG.Features
                 default: return null;
             }
 
-            return [value.ToString("0.000", CultureInfo.InvariantCulture)];
+            return new() {value.ToString("0.000", CultureInfo.InvariantCulture)};
         }
 
         public bool Execute(string[] args)

--- a/Features/TimeSet.cs
+++ b/Features/TimeSet.cs
@@ -48,8 +48,8 @@ namespace FEZUG.Features
 
             if(args[0] == "set")
             {
-                DateTime dateTime = DateTime.Now;
-                if(!DateTime.TryParseExact(args[1], "H:mm", null, DateTimeStyles.None, out dateTime)){
+                if (!DateTime.TryParseExact(args[1], "H:mm", null, DateTimeStyles.None, out DateTime dateTime))
+                {
                     switch (args[1])
                     {
                         case "real": dateTime = DateTime.Now; break;

--- a/Features/TimeSet.cs
+++ b/Features/TimeSet.cs
@@ -18,21 +18,21 @@ namespace FEZUG.Features
         {
             if(args.Length == 1)
             {
-                return [.. new string[] { "set", "speed" }.Where(s => s.StartsWith(args[0]))];
+                return new string[] { "set", "speed" }.Where(s => s.StartsWith(args[0])).ToList();
             }else if(args.Length == 2)
             {
                 if (args[0].Equals("set"))
                 {
-                    return [.. new string[]
+                    return new string[]
                     {
                         TimeManager.CurrentTime.ToString("HH:mm"),
                         "dawn", "day", "dusk", "night", "real"
-                    }.Where(s => s.StartsWith(args[1]))];
+                    }.Where(s => s.StartsWith(args[1])).ToList();
                 }
                 if (args[0].Equals("speed") && args[1].Length == 0)
                 {
                     float curTime = TimeManager.TimeFactor / TimeManager.DefaultTimeFactor;
-                    return [curTime.ToString("0.000", CultureInfo.InvariantCulture) , "real"];
+                    return new() {curTime.ToString("0.000", CultureInfo.InvariantCulture) , "real"};
                 }
             }
             return null;

--- a/Features/Timescaler.cs
+++ b/Features/Timescaler.cs
@@ -33,7 +33,7 @@ namespace FEZUG.Features
         public List<string> Autocomplete(string[] args)
         {
             string timescaleStr = Timescale.ToString("0.000", CultureInfo.InvariantCulture);
-            if (timescaleStr.StartsWith(args[0])) return [timescaleStr];
+            if (timescaleStr.StartsWith(args[0])) return new() {timescaleStr};
             return null;
         }
 

--- a/Features/Timescaler.cs
+++ b/Features/Timescaler.cs
@@ -21,12 +21,12 @@ namespace FEZUG.Features
 
         private static long lastMeasuredRealTimestamp = 0;
         private static long internalTimestamp = 0;
-        
+
         public static float Timescale { get; private set; } = 1.0f;
 
         [ServiceDependency]
         public ISoundManager SoundManager { private get; set; }
-        
+
         public string Name => "timescale";
         public string HelpText => "timescale <value> - changes game's simulation scale";
 
@@ -57,7 +57,7 @@ namespace FEZUG.Features
 
             return true;
         }
-        
+
         private void SetTimescale(float timescale)
         {
             Timescale = Math.Min(Math.Max(timescale, 0.0001f), 100.0f);
@@ -75,7 +75,7 @@ namespace FEZUG.Features
         {
             // TODO?: This could've been done less invasively by manually handling all cases where Stopwatch is used
             // for timing in the game, but they are quite annoying (like in ActiveTrackedSong).
-            
+
             var stopwatchTimestampMethod = Stopwatch.GetTimestamp;
             var newFunc = (Func<long> original) =>
             {
@@ -89,19 +89,19 @@ namespace FEZUG.Features
             {
                 stopwatchTimestampDetour = new Hook(stopwatchTimestampMethod, newFunc);
             }
-            catch (Exception e)
+            catch
             {
                 //TODO the Hook contructor throws an exception if Stopwatch.GetTimestamp is a native extern method
                 //stopwatchTimestampDetour = new NativeDetour(stopwatchTimestampMethod, newFunc);
             }
         }
-        
+
         private void InitializeAudioHooksAndReferences()
         {
             var openAlDeviceType = typeof(SoundEffect).Assembly.GetType("Microsoft.Xna.Framework.Audio.OpenALDevice");
             var setSourcePitchMethod = openAlDeviceType.GetMethod("SetSourcePitch", BindingFlags.Public | BindingFlags.Instance);
             setSourcePitchDetour = new ILHook(setSourcePitchMethod, InjectPitchTweak);
-            
+
             var audioDeviceType = Assembly.GetAssembly(typeof(SoundEffectInstance)).GetType("Microsoft.Xna.Framework.Audio.AudioDevice");
             var soundInstancePoolField = audioDeviceType.GetField("InstancePool", BindingFlags.Public | BindingFlags.Static);
             soundInstancePoolRef = (List<SoundEffectInstance>)soundInstancePoolField!.GetValue(null);
@@ -112,15 +112,15 @@ namespace FEZUG.Features
         private void InjectPitchTweak(ILContext il)
         {
             var cursor = new ILCursor(il);
-            
+
             cursor.Emit(OpCodes.Ldarg_2); // load pitch param
             cursor.EmitDelegate<Func<float, float>>(pitch => pitch + (float)Math.Log(Timescale, 2.0));
             cursor.Emit(OpCodes.Starg, 2);
-            
+
             cursor.Emit(OpCodes.Ldc_I4_0); // false
             cursor.Emit(OpCodes.Starg, 3); // store to clamp argument
         }
-        
+
         private void RefreshSoundPitches()
         {
             foreach (var audio in EnumerateActiveSoundsForPitchUpdate())
@@ -135,12 +135,12 @@ namespace FEZUG.Features
             foreach (var sound in dynamicSoundInstancePoolRef) yield return sound;
             foreach (var emitter in SoundManager.Emitters) yield return emitter.Cue;
         }
-        
+
         public void Update(GameTime gameTime){}
 
         public void DrawHUD(GameTime gameTime) { }
         public void DrawLevel(GameTime gameTime) { }
-        
+
         public static GameTime GetUnscaledGameTime(GameTime originalGameTime)
         {
             return new GameTime(

--- a/Features/TrileCollisionsDraw.cs
+++ b/Features/TrileCollisionsDraw.cs
@@ -96,8 +96,6 @@ namespace FEZUG.Features
 
             DrawingTools.GraphicsDevice.PrepareStencilWrite(StencilMask.Level);
 
-            var cameraViewpoint = CameraManager.Viewpoint.VisibleOrientation();
-
             foreach (var trile in LevelManager.Triles)
             {
                 Dictionary<FaceOrientation, CollisionType> faces = trile.Value.Trile.Faces;
@@ -146,7 +144,7 @@ namespace FEZUG.Features
                         Instance.ShowNone = !Instance.ShowNone;
                         return $"Wireframes for the \"None\" CollisionType have been {(Instance.ShowNone ? "enabled" : "disabled")}.";
                     }
-                } 
+                }
             };
         }
     }

--- a/Features/TrileCollisionsDraw.cs
+++ b/Features/TrileCollisionsDraw.cs
@@ -27,8 +27,8 @@ namespace FEZUG.Features
             {CollisionType.TopNoStraightLedge, Color.Yellow},
         };
 
-        private readonly Dictionary<TrileEmplacement, Dictionary<FaceOrientation, CollisionType>> invisibleTriles = [];
-        private readonly Dictionary<CollisionType, Mesh> CollisionMeshes = [];
+        private readonly Dictionary<TrileEmplacement, Dictionary<FaceOrientation, CollisionType>> invisibleTriles = new();
+        private readonly Dictionary<CollisionType, Mesh> CollisionMeshes = new();
 
         protected override Mesh[] RefreshBoundingBoxMeshs()
         {
@@ -78,7 +78,7 @@ namespace FEZUG.Features
                     }
                 });
             }
-            return [.. CollisionMeshes.Values];
+            return CollisionMeshes.Values.ToArray();
         }
         protected override void RefreshLevelList()
         {

--- a/Features/VolumeDraw.cs
+++ b/Features/VolumeDraw.cs
@@ -24,21 +24,21 @@ namespace FEZUG.Features
             Other
         }
 
-        private readonly Dictionary<int, VolumeType> volumes = [];
+        private readonly Dictionary<int, VolumeType> volumes = new();
 
         private static Mesh[] VolumeBoundingBoxes = null;
 
         protected override Mesh[] RefreshBoundingBoxMeshs()
         {
-            Color[] volColors =
-            [
+            Color[] volColors = new Color[]
+            {
                 Color.Black,
                 Color.Gold,
                 Color.Blue,
                 Color.Gray,
                 Color.Lime,
                 Color.Purple
-            ];
+            };
             int VolTypeCount = volColors.Length;
             VolumeBoundingBoxes = new Mesh[VolTypeCount];
 

--- a/Features/VolumeDraw.cs
+++ b/Features/VolumeDraw.cs
@@ -1,5 +1,4 @@
-﻿using FezEngine.Effects;
-using FezEngine.Structure;
+﻿using FezEngine.Structure;
 using FezEngine.Tools;
 using FEZUG.Helpers;
 using Microsoft.Xna.Framework;
@@ -25,7 +24,7 @@ namespace FEZUG.Features
             Other
         }
 
-        private Dictionary<int, VolumeType> volumes = [];
+        private readonly Dictionary<int, VolumeType> volumes = [];
 
         private static Mesh[] VolumeBoundingBoxes = null;
 

--- a/Features/VolumeInfo.cs
+++ b/Features/VolumeInfo.cs
@@ -20,7 +20,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-		public List<string> Autocomplete(string[] _args) { return []; }
+		public List<string> Autocomplete(string[] _args) { return new(); }
 
 		public bool Execute(string[] args)
 		{
@@ -102,7 +102,7 @@ namespace FEZUG.Features
 
         public void Initialize() { }
 
-        public List<string> Autocomplete(string[] _args) { return []; }
+        public List<string> Autocomplete(string[] _args) { return new(); }
 
         public bool Execute(string[] args)
         {

--- a/Features/WarpLevel.cs
+++ b/Features/WarpLevel.cs
@@ -27,9 +27,9 @@ namespace FEZUG.Features
         {
             get
             {
-				return [.. MemoryContentManager.AssetNames
+				return MemoryContentManager.AssetNames
 				.Where(s => s.ToLower().StartsWith($"levels\\"))
-				.Select(s => s.Substring("levels\\".Length))];
+				.Select(s => s.Substring("levels\\".Length)).ToList();
 			}
 		}
 
@@ -116,7 +116,7 @@ namespace FEZUG.Features
 			}
 
             // make sure no stuff from previous save remains after switching the save.
-            List<IWaiter> waitersToCancel = [.. ServiceHelper.Game.Components.Where(comp => comp is IWaiter).Select(comp => comp as IWaiter)];
+            List<IWaiter> waitersToCancel = ServiceHelper.Game.Components.Where(comp => comp is IWaiter).Select(comp => comp as IWaiter).ToList();
 			foreach (IWaiter waiter in waitersToCancel)
 			{
 				waiter.Cancel();
@@ -136,7 +136,7 @@ namespace FEZUG.Features
 					var TrackedCollectsField = SplitUpCubeHostType.GetField("TrackedCollects", BindingFlags.NonPublic | BindingFlags.Instance);
 					var TrackedCollects = TrackedCollectsField.GetValue(SplitUpCubeHost);
 					MethodInfo TrackedCollectsClear = TrackedCollects.GetType().GetMethod("Clear");
-					TrackedCollectsClear.Invoke(TrackedCollects, []);
+					TrackedCollectsClear.Invoke(TrackedCollects, new object[] {});
 				}
 			}
 
@@ -198,7 +198,7 @@ namespace FEZUG.Features
 
         public List<string> Autocomplete(string[] args)
         {
-			return [.. LevelList.Where(s => s.ToLower().StartsWith($"{args[0]}"))];
+			return LevelList.Where(s => s.ToLower().StartsWith($"{args[0]}")).ToList();
 		}
     }
 }

--- a/Features/WireframeDraw.cs
+++ b/Features/WireframeDraw.cs
@@ -38,7 +38,7 @@ namespace FEZUG.Features
                 Emissive = 1.0f,
                 AlphaIsEmissive = true
             };
-            Mesh m = new Mesh
+            Mesh m = new()
             {
                 DepthWrites = false,
                 Blending = BlendingMode.Alphablending,

--- a/Features/WireframeDraw.cs
+++ b/Features/WireframeDraw.cs
@@ -82,18 +82,18 @@ namespace FEZUG.Features
             private const string xrayOption = "xray";
 
             protected bool AllowXray = false;
-            private string[] Options
+            private List<string> Options
             {
                 get
                 {
+                    List<string> options = new() {onOption, offOption};
                     if (AllowXray)
-                    {
-                        return [onOption, offOption, xrayOption, ..AdditionalChoices.Keys];
-                    }
-                    return [onOption, offOption, ..AdditionalChoices.Keys];
+                        options.Add(xrayOption);
+                    options.AddRange(AdditionalChoices.Keys);
+                    return options;
                 }
             }
-            protected virtual Dictionary<string, Func<string[], string>> AdditionalChoices => [];
+            protected virtual Dictionary<string, Func<string[], string>> AdditionalChoices => new();
 
             protected abstract string WhatFor { get; }
             protected virtual string HelpWhatFor => WhatFor;
@@ -107,7 +107,7 @@ namespace FEZUG.Features
 
             public List<string> Autocomplete(string[] args)
             {
-                return [.. Options.Where(s => s.StartsWith(args[0]))];
+                return Options.Where(s => s.StartsWith(args[0])).ToList();
             }
 
             public bool Execute(string[] args)

--- a/Features/Zoom.cs
+++ b/Features/Zoom.cs
@@ -51,7 +51,7 @@ namespace FEZUG.Features
         {
             if (args.Length == 0 || args[args.Length - 1].Length > 0) return null;
 
-            return [CameraManager.PixelsPerTrixel.ToString("0.000", CultureInfo.InvariantCulture)];
+            return new() {CameraManager.PixelsPerTrixel.ToString("0.000", CultureInfo.InvariantCulture)};
 		}
     }
 }

--- a/Helpers/DrawingTools.cs
+++ b/Helpers/DrawingTools.cs
@@ -28,7 +28,7 @@ namespace FEZUG.Helpers
                 DefaultFontSize = FontManager.BigFactor;
 
                 fillTexture = new Texture2D(GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
-                fillTexture.SetData([new Color(255, 255, 255)]);
+                fillTexture.SetData(new Color[] {new(255, 255, 255)});
             });
         }
 

--- a/Helpers/InputHelper.cs
+++ b/Helpers/InputHelper.cs
@@ -6,8 +6,8 @@ namespace FEZUG.Helpers
 {
     internal class InputHelper
     {
-        private readonly Dictionary<Keys, double> KeyboardRepeatHeldTimers = [];
-        private readonly List<Keys> KeyboardRepeatedPresses = [];
+        private readonly Dictionary<Keys, double> KeyboardRepeatHeldTimers = new();
+        private readonly List<Keys> KeyboardRepeatedPresses = new();
 
         public KeyboardState CurrentKeyboardState { get; private set; }
         public KeyboardState PreviousKeyboardState { get; private set; }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![thumbnail](Docs/thumbnail.png)
 
-## Overview 
+## Overview
 
 This is a [HAT](https://github.com/Krzyhau/HAT) mod which adds some debug functionalities to FEZ - mainly tools for speedrunners, but also for people who want to just mess with the game.
 


### PR DESCRIPTION
This PR changes the LangVersion to 11.0 and addresses all arising issues, which is necessary for running mods on Linux. (73f400233c45658342ea4f11f0696a753dfd113d)

That by itself didn't actually fix FEZUG failing to start - that was caused by an issue with the tuples used in FpsGraph and TextHud. I changed those to use a class and that fixed the issue. (d56709887190cc44e7423ffe4315291b4129f0bf)

In order to make tracking down the issue easier if this exception gets thrown again, I re-throw the exception but with the actual information about which classes are failing to load. (c82c53c16031091a61c3ecf178238e90d19d3c44) Maybe we should do this in HAT instead (and maybe properly show a popup box instead of rethrowing lol)?

Sorry about all of the whitespace formatting changes (maybe we should have a linter?) I also fixed up a bunch of warnings I saw. (04069a54d03065a7ed4d8b073b61c9329caf375b)

~~2020 2021 2022 2023 2024 2025~~ 2026 is the year of the linux desktop :penguin: 